### PR TITLE
detach color picker from DOM

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -115,9 +115,6 @@ function init() {
 
   let picker = document.createElement('input');
   picker.type = 'color';
-  document.body.appendChild(picker);
-  picker.style.cssText = `position: absolute; top: -${picker.offsetHeight}px; left: -${picker.offsetWidth}px;`;
-  picker.value = current;
   picker.addEventListener('input', () => {
     let {value} = picker;
     localStorage.setItem(ITEM_KEY, value);


### PR DESCRIPTION
For convenience, resolve issue: #2.

Tested on *latest* Chrome/Opera, Firefox DE(MS Edge not yet).